### PR TITLE
More snippets, changed old snippets

### DIFF
--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -13,7 +13,7 @@
          :width: ${2:200px}
          :height: ${3:100px}
          :align: ${4:center}
-         :alt: {5:alternate text}
+         :alt: ${5:alternate text}
     """
     'description': 'Inserts image, with additional advanced options.'
     'descriptionMoreURL': 'http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html#image-directive'
@@ -35,7 +35,7 @@
          :width: ${2:200px}
          :height: ${3:100px}
          :align: ${4:center}
-         :alt: {5:alternate text}
+         :alt: ${5:alternate text}
 
          ${2:Caption text}
     """
@@ -118,15 +118,15 @@
     'description': 'Add a block of example code or terminal commands.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block'
 
-  'code block':
-    'prefix': 'codeblock'
+  'literal code block include':
+    'prefix': 'literalinclude'
     'body': """
     .. literalinclude:: ${1:path}
-       :lines: ${2:1,3,5-10,20-}
+       :language: ${2:language}
+       :lines: ${3:1,3,5-10,20-}
     """
     'description': 'Add a block of text from a file, scoped to specific lines.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude'
-
 
   'label':
     'prefix': 'label'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -14,31 +14,31 @@
   'part':
     'prefix': 'part'
     'body': '#########################\n${1:Part title}\n#########################\n'
-    'description': 'Adds part section heading'
+    'description': 'Adds part section heading.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
 
   'chapter':
     'prefix': 'chapter'
     'body': '*************************\n${1:Chapter title}\n*************************\n'
-    'description': 'Adds chapter section heading'
+    'description': 'Adds chapter section heading.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
 
   'section 1':
     'prefix': 'level1'
     'body': '${1:section title}\n=========================$0\n'
-    'description': 'Adds section heading'
+    'description': 'Adds section heading.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
 
   'section 2':
     'prefix': 'level2'
     'body': '${1:subsection title}\n-------------------------$0\n'
-    'description': 'Adds subsection heading'
+    'description': 'Adds subsection heading.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
 
   'section 3':
     'prefix': 'level3'
     'body': '${1:subsubsection title}\n^^^^^^^^^^^^^^^^^^^^^^^^^$0\n'
-    'description': 'Adds subsubsection heading'
+    'description': 'Adds subsubsection heading.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
 
   'figure':

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -2,12 +2,14 @@
   'image':
     'prefix': 'image'
     'body': '.. image:: ${1:path}\n$0'
-  'link':
     'description': 'Inserts image found at the path specified.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#images'
 
+  'external link':
     'prefix': 'link'
     'body': '\\`${1:Title} <${2:http://link}>\\`_$0'
+    'description': 'Adds link to URL external to your documentation.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#external-links'
 
   'part':
     'prefix': 'part'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -69,6 +69,18 @@
     'description': 'Notes can be used to emphasise a point that requires more attention.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
 
+  'warning':
+    'prefix': 'warning'
+    'body': '.. warning::\n\n   ${1:warning text}\n$0'
+    'description': 'Warnings can be used to highlight things that must be done with caution.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
+
+  'seealso':
+    'prefix': 'seealso'
+    'body': '.. seealso::\n\n   ${1:seealso text}\n$0'
+    'description': 'See also can be used to refer to other documents.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
+
   'label':
     'prefix': 'label'
     'body': '.. _${1:label-name}:'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -5,6 +5,19 @@
   'link':
     'prefix': 'link'
     'body': '\\`${1:Title} <${2:http://link}>\\`_$0'
+
+  'part':
+    'prefix': 'part'
+    'body': '#########################\n${1:Part title}\n#########################\n'
+    'description': 'Adds part section heading'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
+
+  'chapter':
+    'prefix': 'chapter'
+    'body': '*************************\n${1:Chapter title}\n*************************\n'
+    'description': 'Adds chapter section heading'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
+
   'section 1':
     'prefix': 'level1'
     'body': '${1:section title}\n=========================$0\n'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -1,4 +1,5 @@
 '.text.sphinx, .source.gfm.sphinx':
+
   'image':
     'prefix': 'image'
     'body': '.. image:: ${1:path}\n$0'
@@ -38,9 +39,8 @@
 
          ${2:Caption text}
     """
-    'description': 'An image with a caption.'
+    'description': 'An image with a caption, with additional advanced options.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
-
 
   'external link':
     'prefix': 'link'
@@ -117,5 +117,5 @@
   'internal reference':
     'prefix': 'ref'
     'body': ':ref:\\`${1:Link title} <${2:label-name}>\\`$0'
-    'description': 'A link to a label within the document.'
+    'description': 'An inline link to a label within the document.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -6,14 +6,23 @@
     'prefix': 'link'
     'body': '\\`${1:Title} <${2:http://link}>\\`_$0'
   'section 1':
-    'prefix': 'sec'
-    'body': '${1:subsection name}\n================$0\n'
+    'prefix': 'level1'
+    'body': '${1:section title}\n=========================$0\n'
+    'description': 'Adds section heading'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
+
   'section 2':
-    'prefix': 'subs'
-    'body': '${1:subsection name}\n****************$0\n'
+    'prefix': 'level2'
+    'body': '${1:subsection title}\n-------------------------$0\n'
+    'description': 'Adds subsection heading'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
+
   'section 3':
-    'prefix': 'sss'
-    'body': '${1:subsection name}\n----------------$0\n'
+    'prefix': 'level3'
+    'body': '${1:subsubsection title}\n^^^^^^^^^^^^^^^^^^^^^^^^^$0\n'
+    'description': 'Adds subsubsection heading'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
+
   'figure':
     'prefix': 'figure'
     'body': '.. figure:: ${1:path}\n$0'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -54,9 +54,18 @@
   'guilabel':
     'prefix': 'guilabel'
     'body': ':guilabel:`${1:label}`$0'
+    'description': 'Labels presented as part of an interactive user interface should be marked using guilabel.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-guilabel'
+
   'menuselection':
     'prefix': 'menuselection'
     'body': ':menuselection:`${1:menu} --> ${2:item}`$0'
+    'description': 'This is used to mark a complete sequence of menu selections, including selecting submenus and choosing a specific operation, or any subsequence of such a sequence.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-menuselection'
+
   'note':
     'prefix': 'note'
     'body': '.. note::\n\n   ${1:note text}\n$0'
+    'description': 'Notes can be used to emphasise a point that requires more attention.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
+

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -43,7 +43,14 @@
 
   'figure':
     'prefix': 'figure'
-    'body': '.. figure:: ${1:path}\n$0'
+    'body': """
+      .. figure:: ${1:path}
+
+         ${2:Caption text}
+    """
+    'description': 'An image with a caption.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
+
   'guilabel':
     'prefix': 'guilabel'
     'body': ':guilabel:`${1:label}`$0'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -5,6 +5,43 @@
     'description': 'Inserts image found at the path specified.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#images'
 
+  'advanced image':
+    'prefix': 'advimage'
+    'body': """
+      .. image:: ${1:path}
+         :width: ${2:200px}
+         :height: ${3:100px}
+         :align: ${4:center}
+         :alt: {5:alternate text}
+    """
+    'description': 'Inserts image, with additional advanced options.'
+    'descriptionMoreURL': 'http://openalea.gforge.inria.fr/doc/openalea/doc/_build/html/source/sphinx/rest_syntax.html#image-directive'
+
+  'figure':
+    'prefix': 'figure'
+    'body': """
+      .. figure:: ${1:path}
+
+         ${2:Caption text}
+    """
+    'description': 'An image with a caption.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
+
+  'advanced figure':
+    'prefix': 'advfigure'
+    'body': """
+      .. figure:: ${1:path}
+         :width: ${2:200px}
+         :height: ${3:100px}
+         :align: ${4:center}
+         :alt: {5:alternate text}
+
+         ${2:Caption text}
+    """
+    'description': 'An image with a caption.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
+
+
   'external link':
     'prefix': 'link'
     'body': '\\`${1:Title} <${2:http://link}>\\`_$0'
@@ -40,16 +77,6 @@
     'body': '${1:subsubsection title}\n^^^^^^^^^^^^^^^^^^^^^^^^^$0\n'
     'description': 'Adds subsubsection heading.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections'
-
-  'figure':
-    'prefix': 'figure'
-    'body': """
-      .. figure:: ${1:path}
-
-         ${2:Caption text}
-    """
-    'description': 'An image with a caption.'
-    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
 
   'guilabel':
     'prefix': 'guilabel'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -8,7 +8,7 @@
   'external link':
     'prefix': 'link'
     'body': '\\`${1:Title} <${2:http://link}>\\`_$0'
-    'description': 'Adds link to URL external to your documentation.'
+    'description': 'Adds link to URL external to your document.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#external-links'
 
   'part':

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -3,6 +3,9 @@
     'prefix': 'image'
     'body': '.. image:: ${1:path}\n$0'
   'link':
+    'description': 'Inserts image found at the path specified.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#images'
+
     'prefix': 'link'
     'body': '\\`${1:Title} <${2:http://link}>\\`_$0'
 

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -69,3 +69,14 @@
     'description': 'Notes can be used to emphasise a point that requires more attention.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
 
+  'label':
+    'prefix': 'label'
+    'body': '.. _${1:label-name}:'
+    'description': 'Used for cross-referencing to arbitrary locations in any document.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations'
+
+  'internal reference':
+    'prefix': 'ref'
+    'body': ':ref:\\`${1:Link title} <${2:label-name}>\\`$0'
+    'description': 'A link to a label within the document.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations'

--- a/snippets/language-sphinx.cson
+++ b/snippets/language-sphinx.cson
@@ -108,6 +108,26 @@
     'description': 'See also can be used to refer to other documents.'
     'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives'
 
+  'code block':
+    'prefix': 'codeblock'
+    'body': """
+    .. code-block:: ${1:language}
+
+       ${2:code content}
+    """
+    'description': 'Add a block of example code or terminal commands.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block'
+
+  'code block':
+    'prefix': 'codeblock'
+    'body': """
+    .. literalinclude:: ${1:path}
+       :lines: ${2:1,3,5-10,20-}
+    """
+    'description': 'Add a block of text from a file, scoped to specific lines.'
+    'descriptionMoreURL': 'http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude'
+
+
   'label':
     'prefix': 'label'
     'body': '.. _${1:label-name}:'


### PR DESCRIPTION
I've added more snippets, and added descriptions and documentation links for existing snippets.

One potentially controversial change is that I have make the sections use the syntax recommended by the [sphinx docs](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections) and [python doc style guide](https://devguide.python.org/documenting/#sections).